### PR TITLE
use event info metadata

### DIFF
--- a/example/logic/paper.md
+++ b/example/logic/paper.md
@@ -38,6 +38,11 @@ affiliations:
     index: 6
 date: 3 March 2020
 bibliography: paper.bib
+event:
+  title: DBCLS BioHackathon 2019
+  url: http\://2019.biohackathon.org/ # colon char must be escaped!
+  location: Fukuoka, Japan
+  group: Logic Programming Working Group
 ---
 
 <!--

--- a/resources/biohackrxiv/latex.template
+++ b/resources/biohackrxiv/latex.template
@@ -407,8 +407,8 @@ $endif$
 
 
   {\bfseries BioHackathon series:} \\
-  \href{http://2019.biohackathon.org/}{\color{linky}{DBCLS BioHackathon 2019}} Fukuoka, Japan \\
-  Logic Programming Working Group
+  \href{$event.url$}{\color{linky}{$event.title$}} {$event.location$} \\
+  {$event.group$} \\
 
 
   \vspace{2mm}


### PR DESCRIPTION
Event information (event title, event URL, event location, and working group name) can be specified in the metadata field of markdown